### PR TITLE
Add status information

### DIFF
--- a/_includes/navigation.md
+++ b/_includes/navigation.md
@@ -1,6 +1,7 @@
 [send2cgeo](#)
 [F.A.Q.](#)
 [Support](#)
+[Status](/status.html)
 [Changelog](https://github.com/cgeo/cgeo/releases)
 [Nightly](nightly.html)
 [Development](https://github.com/cgeo/cgeo)

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -182,6 +182,15 @@ a {
     }
 }
 
+
+.status {
+    position: fixed;
+    left: 0;
+    width: 90%;
+    height: 100%;
+    margin: 6em;
+}
+
 .warning {
     @extend .container;
     width: 0.7 * $contentwidth;
@@ -202,4 +211,3 @@ a {
     p:last-child {
         margin-bottom: 0;
     }
-}

--- a/status.html
+++ b/status.html
@@ -1,0 +1,9 @@
+---
+title: status
+layout: default
+---
+<div class="container">
+  <iframe src="http://status.cgeo.org/status" class="status">
+    Your browser does not support iframes.
+  </iframe>
+</div>


### PR DESCRIPTION
Proof of concept of embedded iframe with status information. Right now, the iframe takes its style information from cgeo.org, but would take it from the new site instead.