### PR TITLE
Add user manual page

### DIFF
--- a/_includes/navigation.md
+++ b/_includes/navigation.md
@@ -1,5 +1,6 @@
 [send2cgeo](https://send2.cgeo.org)
 [FAQ](faq.html)
 [Support](support.html)
+[User Manual](/manual.html)
 [Changelog](https://github.com/cgeo/cgeo/releases)
 [Development](development.html)

--- a/manual.md
+++ b/manual.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: User Manual
+---
+
+# User Manual for c:geo
+
+You are looking for a user manual for c:geo?
+
+The bad news is, that there is no up to date manual for c:geo yet. \\
+We think, that most of the basic functions are self-explanatory or can be found in our [FAQ](/faq.html). But there might be some special features for which it might be good to have a user manual.
+
+The good news is, that you can help creating a manual! \\
+So in case you have some basic knowledge of HTML and some ideas how a user manual for c:geo could look like just contact us as described on our [development page](/development.html).

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -22,10 +22,10 @@ While the import function in c:geo is activated, it transmits about 5kb of data 
 ## How to install send2cgeo?
 <a name="howto"></a>
 
-Important Notes:
-The send2c:geo script supports Firefox and Chrome. Microsoft Internet Explorer is not supported! You need to allow cookies to be stored in your browser in order for the script to work.
+### Important Note:
+The send2c:geo script supports Mozilla Firefox and Google Chrome. Microsoft Internet Explorer is not supported! You need to allow cookies to be stored in your browser in order for the script to work.
 
-Script installation with Firefox:
+### Script installation with Firefox:
 
     Install the greasemonkey add-on: http://addons.mozilla.org/en-US/firefox/addon/greasemonkey/
     Open the send2c:geo script page: https://send2.cgeo.org/script.html
@@ -33,7 +33,7 @@ Script installation with Firefox:
     Greasemonkey will be triggered automatically, confirm the installation when prompted
     Continue with the registration as described below
 
-Script installation with Chrome:
+### Script installation with Chrome:
 
     Install the Tampermonkey add-on
     Open the send2c:geo script page: https://send2.cgeo.org/script.html
@@ -41,7 +41,7 @@ Script installation with Chrome:
     Tampermonkey will be triggered automatically, confirm the installation when prompted
     Continue with the registration as described below
 
-Registering browser and device:
+### Registering browser and device:
 
     After succesful installation of the script click "Register browser" on the right sidebar of the send2c:geo webpage https://send2.cgeo.org
     You can change the browser name by click on its name (optional step)
@@ -51,7 +51,7 @@ Registering browser and device:
     Now click "Add a device" in your browser and enter this PIN
     The webpage should now show a registrated browser and device on the right sidebar
 
-Usage:
+### Usage:
 
     On the geocaching.com website you should now see a "send to c:geo" button on the cache detail page as well as on the live map popup (Next to the existing "Send to my phone" button)
     Clicking this button will add the specific cache to the queue for downloading to c:geo

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -28,7 +28,7 @@ While the import function in c:geo is activated, it transmits about 5kb of data 
 ## How to install send2cgeo?
 <a name="howto"></a>
 
-### Important Note:
+### Prerequisites:
 The send2c:geo script supports Mozilla Firefox and Google Chrome. Microsoft Internet Explorer is not supported! You need to allow cookies to be stored in your browser in order for the script to work.
 
 ### Script installation with Mozilla Firefox:

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -5,7 +5,7 @@ title: Send2cgeo
 
 # Send2cgeo
 
-Send2cgeo is a script available for Mozilla Firefox or Google Chrome browser. It allows you to send geocaches directly from your browser to c:geo on your phone.
+Send2cgeo is a script available for Mozilla Firefox and Google Chrome browser. It allows you to send geocaches directly from your browser to c:geo on your phone.
 
 [How to install send2cgeo?](#howto)\\
 [Get the script!](#script)\\
@@ -26,31 +26,29 @@ While the import function in c:geo is activated, it transmits about 5kb of data 
 ### Important Note:
 The send2c:geo script supports Mozilla Firefox and Google Chrome. Microsoft Internet Explorer is not supported! You need to allow cookies to be stored in your browser in order for the script to work.
 
-### Script installation with Firefox:
+### Script installation with Mozilla Firefox:
 
-    Install the greasemonkey add-on: http://addons.mozilla.org/en-US/firefox/addon/greasemonkey/
-    Open the send2c:geo script page: https://send2.cgeo.org/script.html
-    Start installing the script by clicking on "Start"
-    Greasemonkey will be triggered automatically, confirm the installation when prompted
-    Continue with the registration as described below
+- Install the [greasemonkey add-on](http://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) and make sure it is activated in your browser after installation
+- Start installing the script by clicking [here](https://github.com/cgeo/cgeo/raw/master/send2cgeo/send2cgeo.user.js)
+- Greasemonkey will be triggered automatically, confirm the installation when prompted
+- Continue with the registration as described below
 
-### Script installation with Chrome:
+### Script installation with Google Chrome:
 
-    Install the Tampermonkey add-on
-    Open the send2c:geo script page: https://send2.cgeo.org/script.html
-    Start installing the script by clicking on "Start"
-    Tampermonkey will be triggered automatically, confirm the installation when prompted
-    Continue with the registration as described below
+- Install the [Tampermonkey add-on](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo) and make sure it is activated in your browser after installation
+- Start installing the script by clicking [here](https://github.com/cgeo/cgeo/raw/master/send2cgeo/send2cgeo.user.js)
+- Greasemonkey will be triggered automatically, confirm the installation when prompted
+- Continue with the registration as described below
 
 ### Registering browser and device:
 
-    After succesful installation of the script click "Register browser" on the right sidebar of the send2c:geo webpage https://send2.cgeo.org
-    You can change the browser name by click on its name (optional step)
-    Run c:geo on your android device and select Menu → Settings → Services → send2c:geo
-    Specify a device name in the setting "Your device name" (optional step)
-    Select "Request Registration". You will get an info window showing a five digit PIN
-    Now click "Add a device" in your browser and enter this PIN
-    The webpage should now show a registrated browser and device on the right sidebar
+- After succesful installation of the script click "Register browser" on the right sidebar of the send2cgeo webpage       TO BE COMPLETED 
+- You can change the browser name by click on its name (optional step)
+- Run c:geo on your android device and select Menu → Settings → Services → send2c:geo
+- Specify a device name in the setting "Your device name" (optional step)
+- Select "Request Registration". You will get an info window showing a five digit PIN
+- Now click "Add a device" in your browser and enter this PIN              TO BE COMPLETED
+- The webpage should now show a registrated browser and device on the right sidebar
 
 ## How to use send2cgeo
 <a name="usage"></a>

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -9,6 +9,7 @@ Send2cgeo is a script available for Mozilla Firefox or Google Chrome browser. It
 
 [How to install send2cgeo?](#howto)\\
 [Get the script!](#script)\\
+[Usage instructions for send2cgeo](#usage)\\
 [FAQ for send2cgeo](/faq.html#faq.Whatissend)
 
 ## Disclaimer
@@ -51,14 +52,15 @@ The send2c:geo script supports Mozilla Firefox and Google Chrome. Microsoft Inte
     Now click "Add a device" in your browser and enter this PIN
     The webpage should now show a registrated browser and device on the right sidebar
 
-### Usage:
+## How to use send2cgeo
+<a name="usage"></a>
 
-    On the geocaching.com website you should now see a "send to c:geo" button on the cache detail page as well as on the live map popup (Next to the existing "Send to my phone" button)
-    Clicking this button will add the specific cache to the queue for downloading to c:geo
-    Start c:geo on your device and go to a list of saved caches
-    Select Menu → Manage → Import from web
-    The caches will automatically be downloaded from geocaching.com to the list of saved caches
-    c:geo will continue to wait for more caches to be downloaded for 3 minutes.
+- On the geocaching.com website you should be able to see a "send to c:geo" button on the cache detail page as well as on the live map popup (Next to the existing "Send to my phone" button)
+- Clicking this button will add the specific cache to the queue for downloading to c:geo
+- Start c:geo on your device and go to a list of saved caches
+- Select Menu → Import → Import from web
+- The caches will automatically be downloaded from geocaching.com to the list of saved caches
+- c:geo will continue to wait for more caches to be downloaded for 3 minutes.
 
 ## Get the script!
 <a name="script"></a>

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -17,7 +17,7 @@ Send2cgeo is a script available for Mozilla Firefox and Google Chrome browser. I
 
 [FAQ for send2cgeo](/faq.html#faq.Whatissend)
 
-## Disclaimer
+## Important Notes/Disclaimer
 
 No personal data (except your browser name, your device name and geocodes) will ever be stored on our servers. This service does not use any password and you will never be asked to enter any of your passwords for it.
 

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -33,7 +33,7 @@ The send2c:geo script supports Mozilla Firefox and Google Chrome. Microsoft Inte
 
 ### Script installation with Mozilla Firefox:
 
-- Install the [greasemonkey add-on](http://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) and make sure it is activated in your browser after installation
+- Install the [Greasemonkey add-on](http://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) and make sure it is activated in your browser after installation
 - Start installing the script by clicking [here](https://github.com/cgeo/cgeo/raw/master/send2cgeo/send2cgeo.user.js)
 - Greasemonkey will be triggered automatically, confirm the installation when prompted
 - Continue with the registration as described below
@@ -47,13 +47,13 @@ The send2c:geo script supports Mozilla Firefox and Google Chrome. Microsoft Inte
 
 ### Registering browser and device:
 
-- After succesful installation of the script click "Register browser" on the right sidebar of the send2cgeo webpage       TO BE COMPLETED 
+- After succesful installation of the script click "Register browser" on the right sidebar of the send2cgeo webpage <b>TO BE COMPLETED</b>
 - You can change the browser name by click on its name (optional step)
 - Run c:geo on your android device and select Menu → Settings → Services → send2c:geo
 - Specify a device name in the setting "Your device name" (optional step)
 - Select "Request Registration". You will get an info window showing a five digit PIN
-- Now click "Add a device" in your browser and enter this PIN              TO BE COMPLETED
-- The webpage should now show a registrated browser and device on the right sidebar
+- Now click "Add a device" in your browser and enter this PIN  <b>TO BE COMPLETED</b>
+- The webpage should now show a registrated browser and device on the right sidebar <b>TO BE COMPLETED</b>
 
 ## How to use send2cgeo
 <a name="usage"></a>

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -9,7 +9,7 @@ Send2cgeo is a script available for Mozilla Firefox and Google Chrome browser. I
 
 [How to install send2cgeo](#howto)
 
-[Get the script](#script)
+[Download the script](#script)
 
 [Register browser and/or device](#)
 
@@ -25,7 +25,7 @@ This service comes without any warranty and might be unavailable sometimes (e.g.
 
 While the import function in c:geo is activated, it transmits about 5kb of data over the internet per minute! Beware of this, if you are on 3G and don't have a flatrate.
 
-## How to install send2cgeo?
+## How to install send2cgeo
 <a name="howto"></a>
 
 ### Prerequisites:
@@ -65,10 +65,10 @@ The send2c:geo script supports Mozilla Firefox and Google Chrome. Microsoft Inte
 - The caches will automatically be downloaded from geocaching.com to the list of saved caches
 - c:geo will continue to wait for more caches to be downloaded for 3 minutes.
 
-## Get the script!
+## Download the script
 <a name="script"></a>
 
-Make sure you have Greasemonkey/Tampermonkey installed and active in your browser before continuing.
+Make sure you have Greasemonkey/Tampermonkey **installed and active** in your browser before continuing.
 
 The installation should start automatically in Greasemonkey/Tampermonkey if you click on the link below:\\
 [Script installation](https://github.com/cgeo/cgeo/raw/master/send2cgeo/send2cgeo.user.js)

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -1,0 +1,71 @@
+---
+layout: page
+title: Send2cgeo
+---
+
+# Send2cgeo
+
+Send2cgeo is a script available for Mozilla Firefox or Google Chrome browser. It allows you to send geocaches directly from your browser to c:geo on your phone.
+
+[How to install send2cgeo?](#howto)\\
+[Get the script!](#script)\\
+[FAQ for send2cgeo](/faq.html#faq.Whatissend)
+
+## Disclaimer
+
+No personal data (except your browser name, your device name and geocodes) will ever be stored on our servers. This service does not use any password and you will never be asked to enter any of your passwords for it.
+
+This service comes without any warranty and might be unavailable sometimes (e.g. due to server maintenance).
+
+While the import function in c:geo is activated, it transmits about 5kb of data over the internet per minute! Beware of this, if you are on 3G and don't have a flatrate.
+
+## How to install send2cgeo?
+<a name="howto"></a>
+
+Important Notes:
+The send2c:geo script supports Firefox and Chrome. Microsoft Internet Explorer is not supported! You need to allow cookies to be stored in your browser in order for the script to work.
+
+Script installation with Firefox:
+
+    Install the greasemonkey add-on: http://addons.mozilla.org/en-US/firefox/addon/greasemonkey/
+    Open the send2c:geo script page: https://send2.cgeo.org/script.html
+    Start installing the script by clicking on "Start"
+    Greasemonkey will be triggered automatically, confirm the installation when prompted
+    Continue with the registration as described below
+
+Script installation with Chrome:
+
+    Install the Tampermonkey add-on
+    Open the send2c:geo script page: https://send2.cgeo.org/script.html
+    Start installing the script by clicking on "Start"
+    Tampermonkey will be triggered automatically, confirm the installation when prompted
+    Continue with the registration as described below
+
+Registering browser and device:
+
+    After succesful installation of the script click "Register browser" on the right sidebar of the send2c:geo webpage https://send2.cgeo.org
+    You can change the browser name by click on its name (optional step)
+    Run c:geo on your android device and select Menu → Settings → Services → send2c:geo
+    Specify a device name in the setting "Your device name" (optional step)
+    Select "Request Registration". You will get an info window showing a five digit PIN
+    Now click "Add a device" in your browser and enter this PIN
+    The webpage should now show a registrated browser and device on the right sidebar
+
+Usage:
+
+    On the geocaching.com website you should now see a "send to c:geo" button on the cache detail page as well as on the live map popup (Next to the existing "Send to my phone" button)
+    Clicking this button will add the specific cache to the queue for downloading to c:geo
+    Start c:geo on your device and go to a list of saved caches
+    Select Menu → Manage → Import from web
+    The caches will automatically be downloaded from geocaching.com to the list of saved caches
+    c:geo will continue to wait for more caches to be downloaded for 3 minutes.
+
+## Get the script!
+<a name="script"></a>
+
+Make sure you have Greasemonkey/Tampermonkey installed and active in your browser before continuing.
+
+The installation should start automatically in Greasemonkey/Tampermonkey if you click on the link below:\\
+[Script installation](https://github.com/cgeo/cgeo/raw/master/send2cgeo/send2cgeo.user.js)
+
+

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -9,6 +9,7 @@ Send2cgeo is a script available for Mozilla Firefox and Google Chrome browser. I
 
 [How to install send2cgeo?](#howto)\\
 [Get the script!](#script)\\
+[Register browser/device](#)\\
 [Usage instructions for send2cgeo](#usage)\\
 [FAQ for send2cgeo](/faq.html#faq.Whatissend)
 

--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -7,10 +7,14 @@ title: Send2cgeo
 
 Send2cgeo is a script available for Mozilla Firefox and Google Chrome browser. It allows you to send geocaches directly from your browser to c:geo on your phone.
 
-[How to install send2cgeo?](#howto)\\
-[Get the script!](#script)\\
-[Register browser/device](#)\\
-[Usage instructions for send2cgeo](#usage)\\
+[How to install send2cgeo](#howto)
+
+[Get the script](#script)
+
+[Register browser and/or device](#)
+
+[Usage instructions for send2cgeo](#usage)
+
 [FAQ for send2cgeo](/faq.html#faq.Whatissend)
 
 ## Disclaimer


### PR DESCRIPTION
I just had the idea, that we should add a placeholder for a user manual and use this to ask users who are looking for a manual for help in creating it.

Please merge if you agree with that approach?!

Of course a user manual could have another implementation instead of plain markdown at the end.