### PR TITLE
Use proper typographic characters for minutes and seconds

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -178,13 +178,13 @@
 
             1. Degrees and decimal minutes (MinDec)
 
-                Notation: DDD° MM.MMM'\\
-                Example: N 51° 20.382 E 007° 01.820
+                Notation: DDD° MM.MMM′\\
+                Example: N 51° 20.382′ E 007° 01.820′
 
             2. Degrees, decimal minutes and seconds (DMS)
 
-                Notation: DDD° MM' SS.SSS"\\
-                Example: N 51° 20' 22.920" E 007° 01' 49.200"
+                Notation: DDD° MM′ SS.SSS″\\
+                Example: N 51° 20′ 22.920″ E 007° 01′ 49.200″
 
             3. Only degrees (DegDec)
 


### PR DESCRIPTION
This also adds missing primes for the MinDec example.