### PR TITLE
Add link to workarounds for maps.me problem to FAQ

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -11,12 +11,16 @@
                there have been changes on the maps.me side with their new version which causes this. 
                
                We have opened a support ticket with them, but so far no response from their side, though. You can help by also reporting this bug to maps.me to increase attention.
+
+               Users of c:geo have provided us with workarounds for the techy savvy, see https://github.com/cgeo/cgeo/issues/13209 for details.
         de:
            title: Maps.me kann von c:geo nicht mehr gestartet werden!
            content: |
                Das Problem begann mit einem kürzlichen Update von maps.me. Da wir in c:geo in Bezug auf die maps.me-Anbindung nichts geändert haben, vermuten wir, dass es an der neuen Version von maps.me liegt. 
                
                Wir haben ein Supportticket bei maps.me aufgemacht. Bislang haben wir allerdings noch keine Rückmeldung von maps.me erhalten. Du kannst helfen, indem du ebenfalls eine Fehlermeldung an maps.me sendest um sie darauf aufmerksam zu machen.
+
+               c:geo-Anwender haben uns Workarounds für technisch Versierte vorgeschlagen, siehe https://github.com/cgeo/cgeo/issues/13209 für Details.
       - id: 12667
         en:
             title: The favorite percentage and amount of logs are no longer shown!


### PR DESCRIPTION
Have updated the [Github issue for maps.me](https://github.com/cgeo/cgeo/issues/13209) to include two workarounds provided to us by users.
This PR links the FAQ entry for maps.me to that Github article.