### PR TITLE
improve register/add device instructions

### DIFF
--- a/send2cgeo.md
+++ b/send2cgeo.md
@@ -39,12 +39,12 @@ The send2cgeo script supports Mozilla Firefox and Google Chrome. Microsoft Inter
 
 ## Registering browser and device
 
-- After successful installation of the script click "Register browser" in the window shown below
+- After successful installation of the script click "Register browser" in next to the image below
 - You can change the browser name by click on its name (optional step)
 - Run c:geo on your android device and select Menu → Settings → Services → Send to c:geo
 - Specify a device name in the setting "Your device name" (optional step)
 - Select "Request Registration". You will get an info window showing a five digit PIN
-- Now click "Add a device" in the window shown below and enter this PIN
+- Now click "Add a device" next to the image below and enter this PIN
 - The window below should now show a registered browser and device.
 
 <iframe src="https://send2.cgeo.org/api/" width="100%" height="300px"></iframe>


### PR DESCRIPTION
I was stuck installating send2cgeo as the instructions (to my understanding) instructed me to open/browse to some kind of window that looks like the screenshot in the manual. Turns out it is not a screenshot of a page to browse to, it's just an image with register/add device links next to it. Of course I misunderstood and it's now clear I was not well awake this morning. However, I think a small text change could help people avoid misunderstanding this.