### PR TITLE
Remove nojit version

### DIFF
--- a/development.md
+++ b/development.md
@@ -39,8 +39,6 @@ You can use our nightly builds to test new features of upcoming versions. They a
 
 Nightly builds can cause all kinds of crashes and malfunction. Please report such bugs, but don't expect us to deliver a fix right afterwards. If you need stable functionality, use the normal build.
 
-The version without JIT is necessary for some devices with a MediaTek CPU. If you observe strange behavior in the live map or jumping distances, try the build without JIT.
-
 Please be aware:
 
 Direct downgrading from a nightly version to a production (or beta) version is not possible due to Android versioning restrictions. You need to manually deinstall the nightly and afterwards install the production (or beta) version.
@@ -51,8 +49,7 @@ Please consider this, when using our nightly builds.
 
 ### Download Nightly Builds
 
-[c:geo application](https://download.cgeo.org/cgeo-nightly.apk)\\
-[c:geo application (without JIT)](https://download.cgeo.org/cgeo-nightly-nojit.apk)
+[c:geo application](https://download.cgeo.org/cgeo-nightly.apk)
 
 ## F-Droid repository
 


### PR DESCRIPTION
Remove info about and download link to the nojit version introduced in 2014 to work around a bug in some MediaTek SOCs.